### PR TITLE
Include `requirements.txt` in pip package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+


### PR DESCRIPTION
Following [6c57e20](https://github.com/getindata/doge-datagen/commit/6c57e20d21e75bcad4a9025c17327f7245d6ffec) commit in `doge-datagen` repository, we have to force `setuptools` to include `requirements.txt` generated by CI/CD in pip-ready package. Otherwise, right now one trying to download the package gets the following error:
```sh
$ pip install streamingcli==1.3.0                                                                                                                                                        
Collecting streamingcli==1.3.0
  Downloading streamingcli-1.3.0.tar.gz (28 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/private/var/folders/zm/gmnsnlj967j8zxlx9pwsz6_r0000gn/T/pip-install-7nwi_13i/streamingcli_ce3d01f1277d41f19e011ae760755186/setup.py", line 60, in <module>
          install_requires=get_requirements('requirements.txt'),
        File "/private/var/folders/zm/gmnsnlj967j8zxlx9pwsz6_r0000gn/T/pip-install-7nwi_13i/streamingcli_ce3d01f1277d41f19e011ae760755186/setup.py", line 15, in get_requirements
          with open(filename, "r", encoding="utf-8") as fp:
      FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.
```