### PR TITLE
Convert secret (hidden) variables to env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Convert secret variables (marked with `${variable_name}`) to use environment variables.
+
 ## [1.5.0] - 2022-08-25
 
 ### Added

--- a/tests/streamingcli/jupyter/test_notebook_converter.py
+++ b/tests/streamingcli/jupyter/test_notebook_converter.py
@@ -175,3 +175,55 @@ t_env.execute_sql(f"""CREATE TABLE datagen (
 )""")
 '''
         )
+
+    def test_notebook_hidden_to_env_conversion(self):
+        # given
+        file_path = "tests/streamingcli/resources/jupyter/notebook_env.ipynb"
+        # expect
+        converted_notebook = convert_notebook(file_path)
+        assert (
+            converted_notebook.content
+            == '''import os
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.table import StreamTableEnvironment, DataTypes
+from pyflink.table.udf import udf
+
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_parallelism(1)
+t_env = StreamTableEnvironment.create(env)
+
+
+mysql_table_name = 'datagen'
+
+
+__env_var_0__MY_ENV_VARIABLE = os.environ["MY_ENV_VARIABLE"]
+
+
+t_env.execute_sql(f"""CREATE TABLE datagen (
+    id INT
+) WITH (
+    'connector' = 'datagen',
+    'number-of-rows' = '{__env_var_0__MY_ENV_VARIABLE}'
+)""")
+
+
+__env_var_1__MYSQL_USER = os.environ["MYSQL_USER"]
+
+
+__env_var_2__MYSQL_PASSWORD = os.environ["MYSQL_PASSWORD"]
+
+
+t_env.execute_sql(f"""CREATE TABLE mysql (
+    id INT
+) WITH (
+    'connector' = 'jdbc',
+    'url' = 'jdbc:mysql://localhost:3306/mydatabase',
+    'table-name' = '{mysql_table_name}',
+    'username' = '{__env_var_1__MYSQL_USER}',
+    'password' = '{__env_var_2__MYSQL_PASSWORD}'
+)""")
+
+
+t_env.execute_sql(f"""INSERT INTO mysql (SELECT * FROM datagen)""")
+'''
+        )

--- a/tests/streamingcli/resources/jupyter/notebook_env.ipynb
+++ b/tests/streamingcli/resources/jupyter/notebook_env.ipynb
@@ -1,0 +1,76 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d98a98ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext streamingcli.jupyter.integrations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mysql_table_name = 'datagen'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c74db0bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%flink_execute_sql\n",
+    "CREATE TABLE datagen (\n",
+    "    id INT\n",
+    ") WITH (\n",
+    "    'connector' = 'datagen',\n",
+    "    'number-of-rows' = '${MY_ENV_VARIABLE}'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%flink_execute_sql\n",
+    "CREATE TABLE mysql (\n",
+    "    id INT\n",
+    ") WITH (\n",
+    "    'connector' = 'jdbc',\n",
+    "    'url' = 'jdbc:mysql://localhost:3306/mydatabase',\n",
+    "    'table-name' = '{mysql_table_name}',\n",
+    "    'username' = '${MYSQL_USER}',\n",
+    "    'password' = '${MYSQL_PASSWORD}'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f49d46fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%flink_execute_sql\n",
+    "INSERT INTO mysql (SELECT * FROM datagen)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
#### Description

Converts variables marked with `${}` to use environment variables.

So
```sql
CREATE TABLE aTable (id INT) WITH ('connector' = 'jdbc', 'password' = '${DB_PASSWORD}')
```
in notebook gets converted to something equal to
```sql
CREATE TABLE aTable (id INT) WITH ('connector' = 'jdbc', 'password' = '{os.environ["DB_PASSWORD"]}')
```

##### PR Checklist
- [X] Tests added
- [X] [Changelog](CHANGELOG.md) updated
